### PR TITLE
HTTPS wikipedia URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>most.js examples</title>
+  <style>
+    ul {
+      line-height: 2;
+    }
+  </style>
+</head>
+<body>
+  <h1>most.js examples</h1>
+  <ul>
+    <li><a href="add-inputs/index.html">Add Inputs</a></li>
+    <li><a href="drag-n-drop/index.html">Drag n Drop</a></li>
+    <li><a href="mouse-position/index.html">Mouse Position</a></li>
+    <li><a href="type-to-search/index.html">Type to Search</a></li>
+  </ul>
+</body>
+</html>

--- a/type-to-search/app.js
+++ b/type-to-search/app.js
@@ -6390,7 +6390,7 @@ var _jsonp2 = _interopRequireDefault(_jsonp);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var url = 'http://en.wikipedia.org/w/api.php?action=opensearch&format=json&search=';
+var url = 'https://en.wikipedia.org/w/api.php?action=opensearch&format=json&search=';
 
 var search = document.getElementById('search');
 var resultList = document.getElementById('results');

--- a/type-to-search/index.html
+++ b/type-to-search/index.html
@@ -10,7 +10,7 @@
 <ul id="results"></ul>
 
 <div id="template" style="display: none">
-    <li><a href="http://en.wikipedia.org/wiki/{name}">{name}</a></li>
+    <li><a href="https://en.wikipedia.org/wiki/{name}">{name}</a></li>
 </div>
 </body>
 <script src="./app.js"></script>

--- a/type-to-search/index.js
+++ b/type-to-search/index.js
@@ -2,7 +2,7 @@ import { input } from '@most/dom-event'
 import { map, filter, debounce, skipRepeats, switchLatest, fromPromise } from 'most'
 import rest from 'rest/client/jsonp'
 
-  const url = 'http://en.wikipedia.org/w/api.php?action=opensearch&format=json&search='
+  const url = 'https://en.wikipedia.org/w/api.php?action=opensearch&format=json&search='
 
   const search = document.getElementById('search')
   const resultList = document.getElementById('results')


### PR DESCRIPTION
Oops my bad... I should have specified in https://github.com/mostjs/examples/pull/7, this was kind of dependent on https://github.com/mostjs/examples/pull/6 being merged too.

While https://github.com/mostjs/examples/pull/6 is being worked on please could you merge this as it's needed for the wikipedia search to work on https://mostjs.github.io/examples/type-to-search/index.html